### PR TITLE
Add onClick and onHighlight callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sinon": "^1.17.6"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0"
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.11.6"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,1 @@
+export declare module "react-taggy"

--- a/src/index.js
+++ b/src/index.js
@@ -44,14 +44,15 @@ const Taggy = ({ text = '', spans = [], ents = [],
     // Initialize an empty array that will hold the text and entities
     let jsx = []
 
+    // Make sure spans are ordered by they start index
+    spans.sort((a,b) => (a.start > b.start) ? 1 : ((b.start > a.start) ? -1 : 0))
+
     // METHOD 1 - STRING
     if (typeof text === 'string') {
         // Initialize an empty array. The contents of 'elements' will eventually get pushed to the 'jsx' array, and will be converted to jsx markup in the process.
         let elements = []
         // Keep track of location in the string of text
         let offset = 0
-        // Make sure spans are ordered by they start index
-        spans.sort((a,b) => (a.start > b.start) ? 1 : ((b.start > a.start) ? -1 : 0))
         // Loop through the spans, using the span data to construct the 'elements' array
         spans.forEach((span) => {
             // Create a string of text that does not contain any entities
@@ -153,11 +154,11 @@ const Taggy = ({ text = '', spans = [], ents = [],
         let tokens = text
         // Loop through the 'spans' array. Use the span data to update our 'tokens' array with entities
         for (let s = 0; s < spans.length; s++) {
-            tokens[spans[s].index] = {
-                token: tokens[spans[s].index],
-                type: spans[s].type
-            }
+            tokens[spans[s].index] = spans[s] 
+            tokens[spans[s].index].token = tokens[spans[s].index]
+            tokens[spans[s].index].type = spans[s].type
         }
+        
         // Loop through the tokens array, looking for multi-word entities
         for (let t = 0; t < tokens.length; t++) {
             // Check if we've stopped at an entity

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,13 @@
 import React from 'react'
 
 // Define functional component. Destructure the props.
-const Taggy = ({ text = '', spans = [], ents = [],
-        onClick = (event, tag, elemIndex) => {},
-        onMouseOver = (event, tag, elemIndex) => {},
-        onHighlight = (event, text, spanIndex, start, end) => {},
+const Taggy = ({
+    text = '',
+    spans = [],
+    ents = [],
+    onClick = (event, tag, elemIndex) => {},
+    onMouseOver = (event, tag, elemIndex) => {},
+    onHighlight = (event, text, spanIndex, start, end) => {},
 }) => {
 
     // Find the correct color of the given entity type. If the given entity is not found, set the color to grey.

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIn
         })
         let tagIndex = 0;
         // Loop through our 'tokens' array. Push strings directly to the 'jsx' array. Convert entity objects to jsx markup, then push to the 'jsx' array.
-        tokensWithSpaces.forEach(t => {
+        tokensWithSpaces.forEach((t, i) => {
             if (typeof t === 'string') {
                 jsx.push(t)
             }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import React from 'react'
 
 // Define functional component. Destructure the props.
-const Taggy = ({ text = '', spans = [], ents = [], 
-        onClick = (event, tag, elemIndex) => {}, 
-        onHighlight = (event, text, spanIndex, start, end) => {}
+const Taggy = ({ text = '', spans = [], ents = [],
+        onClick = (event, tag, elemIndex) => {},
+        onMouseOver = (event, tag, elemIndex) => {},
+        onHighlight = (event, text, spanIndex, start, end) => {},
 }) => {
 
     // Find the correct color of the given entity type. If the given entity is not found, set the color to grey.
@@ -93,15 +94,16 @@ const Taggy = ({ text = '', spans = [], ents = [],
         // Loop through our 'elements' array. Push strings directly to the 'jsx' array. Convert entity objects to jsx markup, then push to the 'jsx' array.
         elements.forEach((t, i) => {
             if (typeof t === 'string') {
-                jsx.push(<span 
-                    onMouseUp={(e) => {highlightCallback(e, t, i)}} 
-                    onDoubleClick={(e) => {highlightCallback(e, t, i)}} 
+                jsx.push(<span
+                    onMouseUp={(e) => {highlightCallback(e, t, i)}}
+                    onDoubleClick={(e) => {highlightCallback(e, t, i)}}
                 >{t}</span>)
             }
             else {
                 jsx.push(
                     <mark
                         onClick={(e) => onClick(e, t, i)}
+                        onMouseOver={(e) => onMouseOver(e, t, i)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',
@@ -154,11 +156,11 @@ const Taggy = ({ text = '', spans = [], ents = [],
         let tokens = text
         // Loop through the 'spans' array. Use the span data to update our 'tokens' array with entities
         for (let s = 0; s < spans.length; s++) {
-            tokens[spans[s].index] = spans[s] 
+            tokens[spans[s].index] = spans[s]
             tokens[spans[s].index].token = tokens[spans[s].index]
             tokens[spans[s].index].type = spans[s].type
         }
-        
+
         // Loop through the tokens array, looking for multi-word entities
         for (let t = 0; t < tokens.length; t++) {
             // Check if we've stopped at an entity
@@ -189,15 +191,16 @@ const Taggy = ({ text = '', spans = [], ents = [],
         // Loop through our 'tokens' array. Push strings directly to the 'jsx' array. Convert entity objects to jsx markup, then push to the 'jsx' array.
         tokensWithSpaces.forEach((t, i) => {
             if (typeof t === 'string') {
-                jsx.push(<span 
-                    onMouseUp={(e) => {highlightCallback(e, t, i)}} 
-                    onDoubleClick={(e) => {highlightCallback(e, t, i)}} 
+                jsx.push(<span
+                    onMouseUp={(e) => {highlightCallback(e, t, i)}}
+                    onDoubleClick={(e) => {highlightCallback(e, t, i)}}
                 >{t}</span>)
             }
             else {
                 jsx.push(
                     <mark
                         onClick={(e) => onClick(e, t, i)}
+                        onMouseOver={(e) => onMouseOver(e, t, i)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // Define functional component. Destructure the props.
-const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIndex, tagIndex) => {}}) => {
+const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIndex) => {}}) => {
 
     // Find the correct color of the given entity type. If the given entity is not found, set the color to grey.
     const findRed = (type) => {
@@ -77,16 +77,15 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIn
         }
         // Filter out the consecutive entities that were marked as duplicates
         elements = elements.filter(val => !!val)
-        let tagIndex = 0;
         // Loop through our 'elements' array. Push strings directly to the 'jsx' array. Convert entity objects to jsx markup, then push to the 'jsx' array.
-        elements.forEach(t => {
+        elements.forEach((t, i) => {
             if (typeof t === 'string') {
                 jsx.push(t)
             }
             else {
                 jsx.push(
                     <mark
-                        onClick={(e) => onClick(e, t, i, tagIndex)}
+                        onClick={(e) => onClick(e, t, i)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',
@@ -130,7 +129,6 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIn
                         </span>
                     </mark>
                 )
-                tagIndex++
             }
         })
     }
@@ -173,7 +171,6 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIn
             }
             return t
         })
-        let tagIndex = 0;
         // Loop through our 'tokens' array. Push strings directly to the 'jsx' array. Convert entity objects to jsx markup, then push to the 'jsx' array.
         tokensWithSpaces.forEach((t, i) => {
             if (typeof t === 'string') {
@@ -182,7 +179,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIn
             else {
                 jsx.push(
                     <mark
-                        onClick={(e) => onClick(e, t, i, tagIndex)}
+                        onClick={(e) => onClick(e, t, i)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',
@@ -226,7 +223,6 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIn
                         </span>
                     </mark>
                 )
-                tagIndex++
             }
         })
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // Define functional component. Destructure the props.
-const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index) => {}}) => {
+const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, elemIndex, tagIndex) => {}}) => {
 
     // Find the correct color of the given entity type. If the given entity is not found, set the color to grey.
     const findRed = (type) => {
@@ -77,6 +77,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index)
         }
         // Filter out the consecutive entities that were marked as duplicates
         elements = elements.filter(val => !!val)
+        let tagIndex = 0;
         // Loop through our 'elements' array. Push strings directly to the 'jsx' array. Convert entity objects to jsx markup, then push to the 'jsx' array.
         elements.forEach(t => {
             if (typeof t === 'string') {
@@ -85,7 +86,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index)
             else {
                 jsx.push(
                     <mark
-                        onClick={(e) => onClick(e, t, i)}
+                        onClick={(e) => onClick(e, t, i, tagIndex)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',
@@ -129,6 +130,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index)
                         </span>
                     </mark>
                 )
+                tagIndex++
             }
         })
     }
@@ -171,6 +173,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index)
             }
             return t
         })
+        let tagIndex = 0;
         // Loop through our 'tokens' array. Push strings directly to the 'jsx' array. Convert entity objects to jsx markup, then push to the 'jsx' array.
         tokensWithSpaces.forEach(t => {
             if (typeof t === 'string') {
@@ -179,7 +182,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index)
             else {
                 jsx.push(
                     <mark
-                        onClick={(e) => onClick(e, t, i)}
+                        onClick={(e) => onClick(e, t, i, tagIndex)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',
@@ -223,6 +226,7 @@ const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index)
                         </span>
                     </mark>
                 )
+                tagIndex++
             }
         })
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // Define functional component. Destructure the props.
-const Taggy = ({ text = '', spans = [], ents = []}) => {
+const Taggy = ({ text = '', spans = [], ents = [], onClick = (event, tag, index) => {}}) => {
 
     // Find the correct color of the given entity type. If the given entity is not found, set the color to grey.
     const findRed = (type) => {
@@ -85,6 +85,7 @@ const Taggy = ({ text = '', spans = [], ents = []}) => {
             else {
                 jsx.push(
                     <mark
+                        onClick={(e) => onClick(e, t, i)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',
@@ -178,6 +179,7 @@ const Taggy = ({ text = '', spans = [], ents = []}) => {
             else {
                 jsx.push(
                     <mark
+                        onClick={(e) => onClick(e, t, i)}
                         style={{
                             padding: '0.25em 0.35em',
                             margin: '0px 0.25em',


### PR DESCRIPTION
Hi @johncmunson , thanks a lot for this simple, yet useful library!

I added callbacks when a tag is clicked or the text is highlighted, plus fixed small things

It was mentioned in this issue: https://github.com/johncmunson/react-taggy/issues/2

Here are the detailed changes:
* Add a `clickTag(event, tag, elemIndex)` prop to pass a function triggered when a tag is clicked (useful to edit or delete tags)
* Add a `onHighlight(event, text, spanIndex, start, end)` prop to pass a function triggered when text is highlighted using the mouse (useful to add new tags)
* Additional properties passed to the `spans` objects are now kept (instead of just adding `start`, `end` and `token`)
* Fix bug when the `spans` array is not sorted by start position

You can see it in action here (after running the prediction): https://collaboratory.semanticscience.org 